### PR TITLE
Fix invisible terminal cursor in neovim

### DIFF
--- a/colors/ayu.vim
+++ b/colors/ayu.vim
@@ -195,7 +195,6 @@ exe "hi! CursorLineConceal" .s:fg_guide   .s:bg_line        .s:fmt_none
 " Terminal in NVIM
 " ---------
 if has("nvim")
-  exec "hi! TermCursor"     .s:fg_bg    .s:bg_fg
   let g:terminal_color_0 =  s:palette.bg[s:style]
   let g:terminal_color_1 =  s:palette.markup[s:style]
   let g:terminal_color_2 =  s:palette.string[s:style]


### PR DESCRIPTION
This fixes #15

Confirmed on:
nvim: v0.2.0 Build type: Release
Terminal: iTerm2 Build 3.1.beta.6
