### PR TITLE
fix: Fix outside focus base color light theme

### DIFF
--- a/autoload/airline/themes/ayu.vim
+++ b/autoload/airline/themes/ayu.vim
@@ -5,7 +5,7 @@ let s:c = {}
 
 if ayucolor == 'light'
   " Base colors.
-  let s:c.base0 = { 'gui': '#151a1e', 'cterm': 0 }
+  let s:c.base0 = { 'gui': '#EAEAEA', 'cterm': 0 }
   let s:c.base1 = { 'gui': '#FAFAFA', 'cterm': 8 }
   let s:c.base2 = { 'gui': '#FAFAFA', 'cterm': 10 }
   let s:c.base3 = { 'gui': '#FAFAFA', 'cterm': 12 }


### PR DESCRIPTION
In addition to #39  I forgot to set the color base in case it's outside of the focus( split windows or ctrl-p). This small fix makes it with a slightly grey background, so you can differentiate easily when you are not focused on that window.