### PR TITLE
Support terminal colors for Vim

### DIFF
--- a/colors/ayu.vim
+++ b/colors/ayu.vim
@@ -192,7 +192,7 @@ exe "hi! Conceal"         .s:fg_guide     .s:bg_none        .s:fmt_none
 exe "hi! CursorLineConceal" .s:fg_guide   .s:bg_line        .s:fmt_none
 
 
-" Terminal in NVIM
+" Terminal
 " ---------
 if has("nvim")
   let g:terminal_color_0 =  s:palette.bg[s:style]
@@ -213,6 +213,15 @@ if has("nvim")
   let g:terminal_color_15 = s:palette.comment[s:style]
   let g:terminal_color_background = g:terminal_color_0
   let g:terminal_color_foreground = s:palette.fg[s:style]
+else
+  let g:terminal_ansi_colors =  [s:palette.bg[s:style],      s:palette.markup[s:style]]
+  let g:terminal_ansi_colors += [s:palette.string[s:style],  s:palette.accent[s:style]]
+  let g:terminal_ansi_colors += [s:palette.tag[s:style],     s:palette.constant[s:style]]
+  let g:terminal_ansi_colors += [s:palette.regexp[s:style],  "#FFFFFF"]
+  let g:terminal_ansi_colors += [s:palette.fg_idle[s:style], s:palette.error[s:style]]
+  let g:terminal_ansi_colors += [s:palette.string[s:style],  s:palette.accent[s:style]]
+  let g:terminal_ansi_colors += [s:palette.tag[s:style],     s:palette.constant[s:style]]
+  let g:terminal_ansi_colors += [s:palette.regexp[s:style],  s:palette.comment[s:style]]
 endif
 
 


### PR DESCRIPTION
`g:terminal_color_*` are for Neovim, and there is `g:terminal_ansi_colors` for Vim:
```
							*g:terminal_ansi_colors*
In GUI mode or with 'termguicolors', the 16 ANSI colors used by default in new
terminal windows may be configured using the variable
`g:terminal_ansi_colors`, which should be a list of 16 color names or
hexadecimal color codes, similar to those accepted by |highlight-guifg|.  When
not using GUI colors, the terminal window always uses the 16 ANSI colors of
the underlying terminal.
The |term_setansicolors()| function can be used to change the colors, and
|term_getansicolors()| to get the currently used colors.
```
```
term_setansicolors({buf}, {colors})			*term_setansicolors()*
		Set the ANSI color palette used by terminal {buf}.
		{colors} must be a List of 16 valid color names or hexadecimal
		color codes, like those accepted by |highlight-guifg|.
		Also see |term_getansicolors()| and |g:terminal_ansi_colors|.

		The colors normally are:
			0    black
			1    dark red
			2    dark green
			3    brown
			4    dark blue
			5    dark magenta
			6    dark cyan
			7    light grey
			8    dark grey
			9    red
			10   green
			11   yellow
			12   blue
			13   magenta
			14   cyan
			15   white

		These colors are used in the GUI and in the terminal when
		'termguicolors' is set.  When not using GUI colors (GUI mode
		or 'termguicolors'), the terminal window always uses the 16
		ANSI colors of the underlying terminal.

		Can also be used as a |method|: >
			GetBufnr()->term_setansicolors(colors)

<		{only available with GUI enabled and/or the |+termguicolors|
		feature}
```