### PR TITLE
Updated NERDTree Colors

### DIFF
--- a/colors/ayu.vim
+++ b/colors/ayu.vim
@@ -225,9 +225,9 @@ exe "hi! NERDTreeClosable"          .s:fg_accent      .s:bg_none        .s:fmt_n
 " exe "hi! NERDTreeBookmarkName"      .s:fg_keyword     .s:bg_none        .s:fmt_none
 " exe "hi! NERDTreeCWD"               .s:fg_pink        .s:bg_none        .s:fmt_none
 exe "hi! NERDTreeUp"                .s:fg_fg_idle    .s:bg_none        .s:fmt_none
-exe "hi! NERDTreeDir"               .s:fg_fg_idle    .s:bg_none        .s:fmt_none
-exe "hi! NERDTreeFile"              .s:fg_fg_idle    .s:bg_none        .s:fmt_none
-exe "hi! NERDTreeDirSlash"          .s:fg_guide      .s:bg_none        .s:fmt_none
+exe "hi! NERDTreeDir"               .s:fg_function   .s:bg_none        .s:fmt_none
+exe "hi! NERDTreeFile"              .s:fg_none       .s:bg_none        .s:fmt_none
+exe "hi! NERDTreeDirSlash"          .s:fg_accent     .s:bg_none        .s:fmt_none
 
 
 " GitGutter


### PR DESCRIPTION
On current ayu-vim, the NERDTree is a little bland and dampened — especially in Dark versions. With a few edits NERDTree is now more visible in both Dark and Light.