### PR TITLE
Remove bg_error for signcolumn

### DIFF
--- a/colors/ayu.vim
+++ b/colors/ayu.vim
@@ -178,7 +178,7 @@ exe "hi! Underlined"      .s:fg_tag       .s:bg_none        .s:fmt_undr
 
 exe "hi! Ignore"          .s:fg_none      .s:bg_none        .s:fmt_none
 
-exe "hi! Error"           .s:fg_fg        .s:bg_error       .s:fmt_none
+exe "hi! Error"           .s:fg_fg        .s:bg_panel       .s:fmt_none
 
 exe "hi! Todo"            .s:fg_markup    .s:bg_none        .s:fmt_none
 


### PR DESCRIPTION
When using signcolumn for displaying error symbox, bg_error overlaps symbol currently in use. When set to bg_panel it will match to background color currently used in theme and will solve it. So that we can use any symbol in sign column.

### Screenshot before bg_error and after bg_error was removed

![error-bg](https://user-images.githubusercontent.com/760855/80907187-de94bd80-8d3e-11ea-81d1-10b2759e5f2c.jpg)

Resolves #50