### PR TITLE
Support change background according to the 'background' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,13 @@
 Plug 'ayu-theme/ayu-vim' " or other package manager
 "...
 set termguicolors     " enable true colors support
-let ayucolor="light"  " for light version of theme
+
+set background=light  " for light version of theme
+
+set background=dark   " for mirage or dark version of theme
 let ayucolor="mirage" " for mirage version of theme
 let ayucolor="dark"   " for dark version of theme
+
 colorscheme ayu
 ```
 

--- a/autoload/airline/themes/ayu.vim
+++ b/autoload/airline/themes/ayu.vim
@@ -3,7 +3,7 @@
 " Let's store all the colors in a dictionary.
 let s:c = {}
 
-let s:ayucolor = get(g:, 'ayucolor', 'dark')
+let s:ayucolor = &background ==# 'dark' ? get(g:, 'ayucolor', 'dark') : &background
 
 if s:ayucolor == 'light'
   " Base colors.

--- a/autoload/lightline/colorscheme/ayu.vim
+++ b/autoload/lightline/colorscheme/ayu.vim
@@ -1,4 +1,4 @@
-let s:style = get(g:, 'ayucolor', 'dark')
+let s:style = &background ==# 'dark' ? get(g:, 'ayucolor', 'dark') : &background
 
 let s:fg = {}
 let s:fg.primary    = {'dark': '#E6E1CF', 'light': '#5C6773', 'mirage': '#D9D7CE'}[s:style]

--- a/colors/ayu.vim
+++ b/colors/ayu.vim
@@ -5,7 +5,7 @@ if exists("syntax_on")
   syntax reset
 endif
 
-let s:style = get(g:, 'ayucolor', 'dark')
+let s:style = &background ==# 'dark' ? get(g:, 'ayucolor', 'dark') : &background
 let g:colors_name = "ayu"
 "}}}
 
@@ -269,9 +269,3 @@ hi! link diffAdded String
 "   diffComment
 
 "}}}
-"
-" This is needed for some reason: {{{
-
-let &background = s:style
-
-" }}}


### PR DESCRIPTION
1. The colorscheme now changes to the correct color when `set background` is invoked.
2. `g:ayu_color` now only effective when `background` is `dark`.