### PR TITLE
Fixed colors to follow the ayu-colors standard and tab color fixes

### DIFF
--- a/colors/ayu.vim
+++ b/colors/ayu.vim
@@ -120,8 +120,9 @@ exe "hi! SpellRare"     .s:fg_regexp      .s:bg_none        .s:fmt_undr
 exe "hi! StatusLine"    .s:fg_fg          .s:bg_panel       .s:fmt_none
 exe "hi! StatusLineNC"  .s:fg_fg_idle     .s:bg_panel       .s:fmt_none
 exe "hi! WildMenu"      .s:fg_bg          .s:bg_markup      .s:fmt_none
-exe "hi! TabLine"       .s:fg_fg          .s:bg_panel       .s:fmt_revr
-"   TabLineFill"
+exe "hi! TabLine"       .s:fg_fg          .s:bg_none        .s:fmt_none
+exe "hi! TabLineFill"   .s:fg_bg          .s:bg_none        .s:fmt_none
+exe "hi! TabLineSel"    .s:fg_function    .s:bg_none        .s:fmt_none
 "   TabLineSel"
 exe "hi! Title"         .s:fg_keyword     .s:bg_none        .s:fmt_none
 exe "hi! Visual"        .s:fg_none        .s:bg_selection   .s:fmt_none

--- a/colors/ayu.vim
+++ b/colors/ayu.vim
@@ -14,26 +14,26 @@ let g:colors_name = "ayu"
 
 let s:palette = {}
 
-let s:palette.bg        = {'dark': "#0F1419",  'light': "#FAFAFA",  'mirage': "#212733"}
+let s:palette.bg        = {'dark': "#0A0E14",  'light': "#FAFAFA",  'mirage': "#212733"}
 
-let s:palette.comment   = {'dark': "#5C6773",  'light': "#ABB0B6",  'mirage': "#5C6773"}
+let s:palette.comment   = {'dark': "#626A73",  'light': "#ABB0B6",  'mirage': "#5C6773"}
 let s:palette.markup    = {'dark': "#F07178",  'light': "#F07178",  'mirage': "#F07178"}
 let s:palette.constant  = {'dark': "#FFEE99",  'light': "#A37ACC",  'mirage': "#D4BFFF"}
-let s:palette.operator  = {'dark': "#E7C547",  'light': "#E7C547",  'mirage': "#80D4FF"}
-let s:palette.tag       = {'dark': "#36A3D9",  'light': "#36A3D9",  'mirage': "#5CCFE6"}
+let s:palette.operator  = {'dark': "#F29668",  'light': "#E7C547",  'mirage': "#80D4FF"}
+let s:palette.tag       = {'dark': "#39BAE6",  'light': "#36A3D9",  'mirage': "#5CCFE6"}
 let s:palette.regexp    = {'dark': "#95E6CB",  'light': "#4CBF99",  'mirage': "#95E6CB"}
-let s:palette.string    = {'dark': "#B8CC52",  'light': "#86B300",  'mirage': "#BBE67E"}
+let s:palette.string    = {'dark': "#C2D94C",  'light': "#86B300",  'mirage': "#BBE67E"}
 let s:palette.function  = {'dark': "#FFB454",  'light': "#F29718",  'mirage': "#FFD57F"}
 let s:palette.special   = {'dark': "#E6B673",  'light': "#E6B673",  'mirage': "#FFC44C"}
-let s:palette.keyword   = {'dark': "#FF7733",  'light': "#FF7733",  'mirage': "#FFAE57"}
+let s:palette.keyword   = {'dark': "#FF8F40",  'light': "#FF7733",  'mirage': "#FFAE57"}
 
 let s:palette.error     = {'dark': "#FF3333",  'light': "#FF3333",  'mirage': "#FF3333"}
 let s:palette.accent    = {'dark': "#F29718",  'light': "#FF6A00",  'mirage': "#FFCC66"}
-let s:palette.panel     = {'dark': "#14191F",  'light': "#FFFFFF",  'mirage': "#272D38"}
+let s:palette.panel     = {'dark': "#0D1016",  'light': "#FFFFFF",  'mirage': "#272D38"}
 let s:palette.guide     = {'dark': "#2D3640",  'light': "#D9D8D7",  'mirage': "#3D4751"}
-let s:palette.line      = {'dark': "#151A1E",  'light': "#F3F3F3",  'mirage': "#242B38"}
-let s:palette.selection = {'dark': "#253340",  'light': "#F0EEE4",  'mirage': "#343F4C"}
-let s:palette.fg        = {'dark': "#E6E1CF",  'light': "#5C6773",  'mirage': "#D9D7CE"}
+let s:palette.line      = {'dark': "#00010A",  'light': "#F3F3F3",  'mirage': "#242B38"}
+let s:palette.selection = {'dark': "#273747",  'light': "#F0EEE4",  'mirage': "#343F4C"}
+let s:palette.fg        = {'dark': "#B3B1AD",  'light': "#5C6773",  'mirage': "#D9D7CE"}
 let s:palette.fg_idle   = {'dark': "#3E4B59",  'light': "#828C99",  'mirage': "#607080"}
 
 "}}}


### PR DESCRIPTION
The ayu vim theme didn't respect the colors in https://github.com/ayu-theme/ayu-colors so I fixed them
The tab colors also didn't look very good so I changed that too 
<img width="208" alt="Capture d’écran 2021-02-09 à 14 08 28" src="https://user-images.githubusercontent.com/70319920/107368061-5c60d300-6ae0-11eb-96d6-7fd531585b61.png">
<img width="804" alt="Capture d’écran 2021-02-09 à 14 08 55" src="https://user-images.githubusercontent.com/70319920/107368066-5d920000-6ae0-11eb-8529-1a48378f151a.png">

