### PR TITLE
Fix invalid argument for Mirage, add vertsplit background

### DIFF
--- a/colors/ayu.vim
+++ b/colors/ayu.vim
@@ -96,7 +96,7 @@ exe "hi! DiffAdd"       .s:fg_string      .s:bg_panel       .s:fmt_none
 exe "hi! DiffChange"    .s:fg_tag         .s:bg_panel       .s:fmt_none
 exe "hi! DiffText"      .s:fg_fg          .s:bg_panel       .s:fmt_none
 exe "hi! ErrorMsg"      .s:fg_fg          .s:bg_error       .s:fmt_stnd
-exe "hi! VertSplit"     .s:fg_bg          .s:bg_none        .s:fmt_none
+exe "hi! VertSplit"     .s:fg_bg          .s:bg_line        .s:fmt_none
 exe "hi! Folded"        .s:fg_fg_idle     .s:bg_panel       .s:fmt_none
 exe "hi! FoldColumn"    .s:fg_none        .s:bg_panel       .s:fmt_none
 exe "hi! SignColumn"    .s:fg_none        .s:bg_panel       .s:fmt_none

--- a/colors/ayu.vim
+++ b/colors/ayu.vim
@@ -272,6 +272,8 @@ hi! link diffAdded String
 "
 " This is needed for some reason: {{{
 
-let &background = s:style
+if !has("nvim")
+  let &background = s:style
+endif
 
 " }}}


### PR DESCRIPTION
* fix complain about `Invalid argument`  on `NVIM v0.8.1` 
* add vertsplit background